### PR TITLE
Fixes formatting on topbeat period value

### DIFF
--- a/templates/topbeat.yml.j2
+++ b/templates/topbeat.yml.j2
@@ -1,6 +1,6 @@
 ---
 input:
-  period: "{{ logstash_client_topbeat_period }}"
+  period: {{ logstash_client_topbeat_period }}
   stats:
     system: true
     process: true


### PR DESCRIPTION
The change introduced in 1d5cad846eb0c006109d12e95605bee6eb4f1889
inappropriately added quotes to the YAML config file, which broke the
parsing. The validator parameter on the template task caught the
regression, but the quotes are hereby removed to ensure proper writing
of the "period" value, which is now configurable.

Fixes #6.