### PR TITLE
Fixes formatting in ssl full path default var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ logstash_client_ssl_certificate_base_directory: /etc/pki/tls/certs
 # for shipping logs. TLS is disabled by default.
 logstash_client_ssl_certificate: ""
 logstash_client_ssl_certificate_fullpath: >-
-  "{{ logstash_client_ssl_certificate_base_directory }}/{{ logstash_client_ssl_certificate | basename }}"
+  {{ logstash_client_ssl_certificate_base_directory }}/{{ logstash_client_ssl_certificate | basename }}
 
 # Sane default of localhost. Override to set to the IP address of the Logstash server.
 # You can also inspect group membership, e.g.:


### PR DESCRIPTION
The changes in abdb5d2f21aec60a8bb2f5fd148cb7e518c5a4e1 introduced a
folding scalar operator in the YAML vars file, but inappropriately
retained the double quotes surrounding the value. The folding operator
makes the string content literal, so the double quotes are no longer
required, and in fact break the template writing. Fortunately the
validate parameter on the template tasks for Topbeat and Filebeat
prevent a broken config from being written to a system.

Fixes #10.