### PR TITLE
Adds support for Ansible v2

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ships logs and metrics to ELK logserver.
   company: Freedom of the Press Foundation (@freedomofpress)
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2
   platforms:
     - name: Debian
       versions:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -28,4 +28,4 @@
   apt:
     name: "{{ item }}"
     state: present
-  with_items: logstash_client_beats_packages
+  with_items: "{{ logstash_client_beats_packages }}"


### PR DESCRIPTION
Removes deprecation warning about old-style `with_items` usage. Explicitly interpolating the listvar with `{{ }}` fixes. Also bumps the required version to Ansible v2, so we're not testing against the 1.x release series at all.