### PR TITLE
Update role to utilize 5.x series beats clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Logstash client Ansible role
-Ansible role for shipping logs and metrics to an ELK logserver.
-Uses [filebeat] and [topbeat], not the deprecated logstash-forwarder.
-Intended for use with the [freedomofpress.elk] role.
+# Beats client Ansible role
+Ansible role for shipping logs and metrics to an ELK logserver via beats agents.
+By default, is ready for installing/configuring [filebeat] and [topbeat].
 
 Requirements
 ------------
-* an ELK logserver to ship to (see the [freedomofpress.elk] role)
+* an ELK logserver to ship to
 
 Role Variables
 --------------
@@ -18,6 +17,15 @@ logstash_client_beats_packages:
   - filebeat
   - topbeat
 
+logstash_client_beats_prereq:
+  - apt-transport-https
+
+# Elastic's PGP key for signing their repository
+logstash_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
+
+# Elastic's beats debian repository
+logstash_elastic_repo_url: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+
 # Set to true to enable ssl - TLS disabled by default
 # If you specify a CA path that will be added to the config,
 #     otherwise the system CA store will be utilized
@@ -26,10 +34,14 @@ logstash_client_ssl_certificate_fullpath: ""
 # only override this for testing, this disables ssl verification
 logstash_output_insecure: false
 
-# Sane default of localhost. Override to set to the IP address of the Logstash server.
+# Sane default of localhost. Override to set to the IP address/DNS of the Logstash server.
 # You can also inspect group membership, e.g.:
 # logstash_client_logserver_ip_address: "{{ hostvars[groups.logserver.0].ansible_default_ipv4.address }}"
-logstash_client_logserver_ip_address: "127.0.0.1"
+logstash_client_logserver: "127.0.0.1"
+logstash_client_port: 5000
+
+# Controls how often Topbeat reports stats (in seconds)
+logstash_client_topbeat_period: 10
 
 # Base logfiles that should be tracked on all hosts.
 logstash_client_logfiles:
@@ -64,6 +76,16 @@ logstash_client_logfiles:
   - paths:
       - /var/log/ufw.log
     document_type: ufw
+
+  - paths:
+      - /var/log/fail2ban.log
+    document_type: fail2ban
+
+  - paths:
+      - /var/log/mail.info
+      - /var/log/mail.warn
+      - /var/log/mail.err
+    document_type: postfix
 
 # To send additional logfiles, override the following list.
 # Make sure each item has "path" and "type" attributes.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ logstash_output_insecure: false
 # Sane default of localhost. Override to set to the IP address of the Logstash server.
 # You can also inspect group membership, e.g.:
 # logstash_client_logserver_ip_address: "{{ hostvars[groups.logserver.0].ansible_default_ipv4.address }}"
-logstash_client_logserver_ip_address: "127.0.0.1"
+logstash_client_logserver: "127.0.0.1"
 logstash_client_port: 5000
 
 # Controls how often Topbeat reports stats (in seconds)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,15 @@ logstash_client_beats_packages:
   - filebeat
   - topbeat
 
+logstash_client_beats_prereq:
+  - apt-transport-https
+
+# Elastic's PGP key for signing their repository
+logstash_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
+
+# Elastic's beats debian repository
+logstash_elastic_repo_url: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+
 # Set to true to enable ssl - TLS disabled by default
 # If you specify a CA path that will be added to the config,
 #     otherwise the system CA store will be utilized

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ logstash_client_ssl_certificate_fullpath: ""
 # only override this for testing, this disables ssl verification
 logstash_output_insecure: false
 
-# Sane default of localhost. Override to set to the IP address of the Logstash server.
+# Sane default of localhost. Override to set to the IP address/DNS of the Logstash server.
 # You can also inspect group membership, e.g.:
 # logstash_client_logserver_ip_address: "{{ hostvars[groups.logserver.0].ansible_default_ipv4.address }}"
 logstash_client_logserver: "127.0.0.1"

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,30 +1,21 @@
 ---
 - name: Add ElasticSearch apt key.
-  become: yes
   apt_key:
-    url: https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    id: "{{ logstash_elastic_pgp_key }}"
+    keyserver: pgp.mit.edu
     state: present
 
-- name: Remove Logstash Forwarder repository
-  become: yes
-  apt_repository:
-    repo: "deb http://packages.elasticsearch.org/logstashforwarder/debian stable main"
-    state: absent
-
-- name: Remove Logstash Forwarder package.
-  become: yes
+- name: Install beats pre-req software
   apt:
-    name: logstash-forwarder
-    state: absent
+    name: "{{ item }}"
+  with_items: "{{ logstash_client_beats_prereq }}"
 
 - name: Add Beats apt repository.
-  become: yes
   apt_repository:
-    repo: "deb http://packages.elastic.co/beats/apt stable main"
+    repo: "{{ logstash_elastic_repo_url }}"
     state: present
 
 - name: Install beat packages.
-  become: yes
   apt:
     name: "{{ item }}"
     state: present

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -13,7 +13,7 @@ output:
   logstash:
     enabled: true
     hosts:
-      - "{{ logstash_client_logserver_ip_address }}:{{ logstash_client_port }}"
+      - "{{ logstash_client_logserver }}:{{ logstash_client_port }}"
 {% if logstash_client_ssl %}
     tls:
 {% if logstash_client_ssl_certificate_fullpath != "" %}

--- a/templates/topbeat.yml.j2
+++ b/templates/topbeat.yml.j2
@@ -10,7 +10,7 @@ output:
   logstash:
     enabled: true
     hosts:
-      - "{{ logstash_client_logserver_ip_address }}:5000"
+      - "{{ logstash_client_logserver }}:5000"
 {% if logstash_client_ssl %}
     tls:
 {% if logstash_client_ssl_certificate_fullpath != "" %}


### PR DESCRIPTION
From a high-level made these changes:

* Removed references to logstash forwarder. It's fairly old now (last update was 2 years ago). We should stop referencing it and I think logic to remove it is outside the scope of this role.
* Added repo, pre-reqs, and PGP key to install 5.x series of beats clients
* Updated documentation a bit to remove references to the our ELK role. Reasoning is that I'm not sure it's compatible with 5.x series of beats clients.

I didn't touch the tests or use the molecule environment. That should all get changed to utilize docker so we can do full E2E testing. Meaning, we should standup a logstash server, try installing this role and firing off events and make sure they make it to the other side :) That's outside the scope of this PR though.